### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/boo13/website/security/code-scanning/25](https://github.com/boo13/website/security/code-scanning/25)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions by adding a `permissions` block either at the workflow root (applies to all jobs) or within the specific job. Here, the simplest and safest change without altering functionality is to declare read-only access to repository contents, since the job only needs to read code to run `npm ci`, `lint`, and `build`. No step requires write access or other scopes.

The single best fix is to add `permissions: contents: read` at the top (root) level of `.github/workflows/ci.yml`, right after the `name: CI` line or before `jobs:`. This will (a) explicitly document that the workflow only needs read access, (b) ensure the workflow remains least-privilege even if repo/org defaults change, and (c) not interfere with any current steps, since they only read from the repository. No imports or external definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
