### PR TITLE
feat(credits): subtle CA flash hover + dim non-hovered rows

### DIFF
--- a/public/data/Projects.json
+++ b/public/data/Projects.json
@@ -5,7 +5,7 @@
       "title": "upNEXT News",
       "platform": "social",
       "year": "2026",
-      "role": "Creative Director",
+      "role": "Executive Producer",
       "description": null,
       "videoStandard": null,
       "videoVertical": null,

--- a/src/sections/credits.js
+++ b/src/sections/credits.js
@@ -88,8 +88,11 @@ export function initCredits() {
   let activeRow = null;
   let activeTween = null;
   let isDisposed = false;
+  let hoveredHeader = null;
+  const cleanupHandlers = [];
 
   const ctx = gsap.context(() => {});
+  section.dataset.caCurve ??= 'fade-only';
 
   const fixedHeroName = document.getElementById('hero-name-fixed');
   const topGradient = document.querySelector('.hero-top-transition-gradient');
@@ -306,6 +309,38 @@ export function initCredits() {
     });
   });
 
+  function setHoveredHeader(nextHeader) {
+    if (hoveredHeader === nextHeader) return;
+
+    hoveredHeader = nextHeader;
+    const headers = list.querySelectorAll('.credit-row__header');
+    headers.forEach((headerEl) => {
+      headerEl.classList.toggle('is-hovered', headerEl === nextHeader);
+    });
+    list.classList.toggle('is-row-hovered', Boolean(nextHeader));
+  }
+
+  function clearHoveredHeader() {
+    setHoveredHeader(null);
+  }
+
+  const handleListPointerLeave = (event) => {
+    if (!event.relatedTarget || !list.contains(event.relatedTarget)) {
+      clearHoveredHeader();
+    }
+  };
+  const handleListFocusOut = (event) => {
+    if (!event.relatedTarget || !list.contains(event.relatedTarget)) {
+      clearHoveredHeader();
+    }
+  };
+  list.addEventListener('pointerleave', handleListPointerLeave);
+  list.addEventListener('focusout', handleListFocusOut);
+  cleanupHandlers.push(() => {
+    list.removeEventListener('pointerleave', handleListPointerLeave);
+    list.removeEventListener('focusout', handleListFocusOut);
+  });
+
   fetch('data/Projects.json')
     .then((response) => response.json())
     .then((data) => {
@@ -314,9 +349,19 @@ export function initCredits() {
       list.innerHTML = '';
       data.projects.forEach((project) => {
         const row = buildRow(project);
-        row.querySelector('.credit-row__header').addEventListener('click', () =>
-          handleRowClick(row)
-        );
+        const header = row.querySelector('.credit-row__header');
+        const handleClick = () => handleRowClick(row);
+        const handlePointerEnter = () => setHoveredHeader(header);
+        const handleFocus = () => setHoveredHeader(header);
+
+        header.addEventListener('click', handleClick);
+        header.addEventListener('pointerenter', handlePointerEnter);
+        header.addEventListener('focus', handleFocus);
+        cleanupHandlers.push(() => {
+          header.removeEventListener('click', handleClick);
+          header.removeEventListener('pointerenter', handlePointerEnter);
+          header.removeEventListener('focus', handleFocus);
+        });
         list.appendChild(row);
       });
 
@@ -348,6 +393,8 @@ export function initCredits() {
 
   return () => {
     isDisposed = true;
+    cleanupHandlers.forEach((cleanup) => cleanup());
+    list.classList.remove('is-row-hovered');
     ctx.revert();
   };
 }

--- a/src/styles/index2.css
+++ b/src/styles/index2.css
@@ -686,6 +686,18 @@ body.show-grid .bg-columns {
   --credits-border: oklch(0.14 0 0 / 0.1);
   --credits-hover-bg: oklch(0.14 0 0 / 0.04);
   --credits-muted: oklch(0.14 0 0 / 0.5);
+  /* Dim non-hovered rows (fixed values) */
+  --credits-dim-blur: 0.7px;
+  --credits-dim-opacity: 0.2;
+  --credits-dim-duration: 1000ms;
+  --credits-dim-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* CA flash (driven by tweak pane) */
+  --credits-ca-offset: 2px;
+  --credits-ca-blur: 2px;
+  --credits-ca-opacity: 0.9;
+  --credits-ca-duration: 1500ms;
+  --credits-ca-blue: oklch(0.804 0.146 220);
+  --credits-ca-red: oklch(0.656 0.235 13);
   position: relative;
   padding: var(--section-padding) 0;
   background: var(--credits-bg);
@@ -731,15 +743,6 @@ body.show-grid .bg-columns {
   background: var(--credits-hover-bg);
 }
 
-.credit-row__header:active {
-  transform: scale(0.98);
-  transition: transform 0.1s ease;
-}
-
-.credit-row__header:hover .credit-row__title {
-  --ca-spread: 5px;
-}
-
 .credit-row__icon {
   font-size: 1rem;
   font-weight: 300;
@@ -756,21 +759,9 @@ body.show-grid .bg-columns {
   transform: rotate(45deg);
 }
 
-@property --ca-spread {
-  syntax: '<length>';
-  initial-value: 0px;
-  inherits: false;
-}
-
 .credit-row__title {
   font-size: clamp(1.05rem, 2vw, 1.35rem);
   font-weight: 400;
-  transition:
-    color 0.25s ease,
-    --ca-spread 0.5s var(--ease-out-expo);
-  text-shadow:
-    calc(var(--ca-spread) * -1) 0 oklch(0.804 0.146 220 / 0.9),
-    var(--ca-spread) 0 oklch(0.656 0.235 13 / 0.9);
 }
 
 .credit-row__platform,
@@ -779,6 +770,93 @@ body.show-grid .bg-columns {
   color: var(--credits-muted);
   text-transform: uppercase;
   letter-spacing: 0.07em;
+}
+.credit-row__title,
+.credit-row__platform,
+.credit-row__role {
+  opacity: 1;
+  filter: blur(0px);
+  transition:
+    color 0.25s ease,
+    opacity var(--credits-dim-duration) var(--credits-dim-ease),
+    filter var(--credits-dim-duration) var(--credits-dim-ease);
+}
+
+.credits-list.is-row-hovered .credit-row__header .credit-row__title,
+.credits-list.is-row-hovered .credit-row__header .credit-row__platform,
+.credits-list.is-row-hovered .credit-row__header .credit-row__role {
+  opacity: var(--credits-dim-opacity);
+  filter: blur(var(--credits-dim-blur));
+}
+
+.credits-list.is-row-hovered .credit-row__header.is-hovered .credit-row__title,
+.credits-list.is-row-hovered .credit-row__header.is-hovered .credit-row__platform,
+.credits-list.is-row-hovered .credit-row__header.is-hovered .credit-row__role {
+  opacity: 1;
+  filter: blur(0px);
+}
+
+/* CA flash keyframes — three decay curves */
+@keyframes credits-ca-shrink-fade {
+  from {
+    text-shadow:
+      calc(var(--credits-ca-offset) * -1) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-blue), transparent calc((1 - var(--credits-ca-opacity)) * 100%)),
+      var(--credits-ca-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-red), transparent calc((1 - var(--credits-ca-opacity)) * 100%));
+  }
+  to {
+    text-shadow:
+      0 0 0 transparent,
+      0 0 0 transparent;
+  }
+}
+
+@keyframes credits-ca-fade-only {
+  from {
+    text-shadow:
+      calc(var(--credits-ca-offset) * -1) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-blue), transparent calc((1 - var(--credits-ca-opacity)) * 100%)),
+      var(--credits-ca-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-red), transparent calc((1 - var(--credits-ca-opacity)) * 100%));
+  }
+  to {
+    text-shadow:
+      calc(var(--credits-ca-offset) * -1) 0 var(--credits-ca-blur) transparent,
+      var(--credits-ca-offset) 0 var(--credits-ca-blur) transparent;
+  }
+}
+
+@keyframes credits-ca-bloom {
+  from {
+    text-shadow:
+      calc(var(--credits-ca-offset) * -1) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-blue), transparent calc((1 - var(--credits-ca-opacity)) * 100%)),
+      var(--credits-ca-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-red), transparent calc((1 - var(--credits-ca-opacity)) * 100%));
+  }
+  50% {
+    text-shadow:
+      calc(var(--credits-ca-offset) * -0.5) 0 calc(var(--credits-ca-blur) * 2) color-mix(in oklch, var(--credits-ca-blue), transparent calc((1 - var(--credits-ca-opacity) * 0.6) * 100%)),
+      calc(var(--credits-ca-offset) * 0.5) 0 calc(var(--credits-ca-blur) * 2) color-mix(in oklch, var(--credits-ca-red), transparent calc((1 - var(--credits-ca-opacity) * 0.6) * 100%));
+  }
+  to {
+    text-shadow:
+      0 0 0 transparent,
+      0 0 0 transparent;
+  }
+}
+
+/* Apply CA animation via JS-managed .is-hovered class, curve selected by data-ca-curve */
+.credits-section[data-ca-curve='shrink-fade'] .credit-row__header.is-hovered .credit-row__title {
+  animation: credits-ca-shrink-fade var(--credits-ca-duration) var(--ease-out-expo) forwards;
+}
+.credits-section[data-ca-curve='fade-only'] .credit-row__header.is-hovered .credit-row__title {
+  animation: credits-ca-fade-only var(--credits-ca-duration) var(--ease-out-expo) forwards;
+}
+.credits-section[data-ca-curve='bloom'] .credit-row__header.is-hovered .credit-row__title {
+  animation: credits-ca-bloom var(--credits-ca-duration) var(--ease-out-expo) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .credits-section[data-ca-curve] .credit-row__header.is-hovered .credit-row__title {
+    animation: none;
+    text-shadow: none;
+  }
 }
 
 /* Details panel: collapsed by default */
@@ -813,6 +891,7 @@ body.show-grid .bg-columns {
   color: var(--credits-muted);
   align-self: center;
 }
+
 
 /* =====================================================
    CTA Section

--- a/src/styles/index2.css
+++ b/src/styles/index2.css
@@ -694,7 +694,6 @@ body.show-grid .bg-columns {
   /* CA flash (driven by tweak pane) */
   --credits-ca-offset: 2px;
   --credits-ca-blur: 2px;
-  --credits-ca-opacity: 0.9;
   --credits-ca-duration: 1500ms;
   --credits-ca-blue: oklch(0.804 0.146 220);
   --credits-ca-red: oklch(0.656 0.235 13);

--- a/src/styles/index2.css
+++ b/src/styles/index2.css
@@ -698,6 +698,13 @@ body.show-grid .bg-columns {
   --credits-ca-duration: 1500ms;
   --credits-ca-blue: oklch(0.804 0.146 220);
   --credits-ca-red: oklch(0.656 0.235 13);
+  /* Precomputed to avoid typed calc() — Firefox/older Safari don't support multiplying px vars */
+  --credits-ca-neg-offset: -2px;
+  --credits-ca-transparent-pct: 10%;
+  --credits-ca-half-offset: 1px;
+  --credits-ca-neg-half-offset: -1px;
+  --credits-ca-double-blur: 4px;
+  --credits-ca-transparent-bloom-pct: 46%;
   position: relative;
   padding: var(--section-padding) 0;
   background: var(--credits-bg);
@@ -800,8 +807,8 @@ body.show-grid .bg-columns {
 @keyframes credits-ca-shrink-fade {
   from {
     text-shadow:
-      calc(var(--credits-ca-offset) * -1) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-blue), transparent calc((1 - var(--credits-ca-opacity)) * 100%)),
-      var(--credits-ca-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-red), transparent calc((1 - var(--credits-ca-opacity)) * 100%));
+      var(--credits-ca-neg-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-blue), transparent var(--credits-ca-transparent-pct)),
+      var(--credits-ca-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-red), transparent var(--credits-ca-transparent-pct));
   }
   to {
     text-shadow:
@@ -813,12 +820,12 @@ body.show-grid .bg-columns {
 @keyframes credits-ca-fade-only {
   from {
     text-shadow:
-      calc(var(--credits-ca-offset) * -1) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-blue), transparent calc((1 - var(--credits-ca-opacity)) * 100%)),
-      var(--credits-ca-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-red), transparent calc((1 - var(--credits-ca-opacity)) * 100%));
+      var(--credits-ca-neg-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-blue), transparent var(--credits-ca-transparent-pct)),
+      var(--credits-ca-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-red), transparent var(--credits-ca-transparent-pct));
   }
   to {
     text-shadow:
-      calc(var(--credits-ca-offset) * -1) 0 var(--credits-ca-blur) transparent,
+      var(--credits-ca-neg-offset) 0 var(--credits-ca-blur) transparent,
       var(--credits-ca-offset) 0 var(--credits-ca-blur) transparent;
   }
 }
@@ -826,13 +833,13 @@ body.show-grid .bg-columns {
 @keyframes credits-ca-bloom {
   from {
     text-shadow:
-      calc(var(--credits-ca-offset) * -1) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-blue), transparent calc((1 - var(--credits-ca-opacity)) * 100%)),
-      var(--credits-ca-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-red), transparent calc((1 - var(--credits-ca-opacity)) * 100%));
+      var(--credits-ca-neg-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-blue), transparent var(--credits-ca-transparent-pct)),
+      var(--credits-ca-offset) 0 var(--credits-ca-blur) color-mix(in oklch, var(--credits-ca-red), transparent var(--credits-ca-transparent-pct));
   }
   50% {
     text-shadow:
-      calc(var(--credits-ca-offset) * -0.5) 0 calc(var(--credits-ca-blur) * 2) color-mix(in oklch, var(--credits-ca-blue), transparent calc((1 - var(--credits-ca-opacity) * 0.6) * 100%)),
-      calc(var(--credits-ca-offset) * 0.5) 0 calc(var(--credits-ca-blur) * 2) color-mix(in oklch, var(--credits-ca-red), transparent calc((1 - var(--credits-ca-opacity) * 0.6) * 100%));
+      var(--credits-ca-neg-half-offset) 0 var(--credits-ca-double-blur) color-mix(in oklch, var(--credits-ca-blue), transparent var(--credits-ca-transparent-bloom-pct)),
+      var(--credits-ca-half-offset) 0 var(--credits-ca-double-blur) color-mix(in oklch, var(--credits-ca-red), transparent var(--credits-ca-transparent-bloom-pct));
   }
   to {
     text-shadow:


### PR DESCRIPTION
## Summary

- Hover on a credits row title now flashes a subtle red/blue chromatic-aberration text-shadow that fades over 1500ms (fade-only curve, 2px offset, 2px blur, 90% opacity), replacing the old yellow accent color
- Non-hovered rows dim to 20% opacity / 0.7px blur over 1000ms while a row is active; exit transition fixed by writing `blur(0px)` explicitly (avoids the unitless-zero parsing quirk that caused snap-back)
- Three `@keyframes` variants exist in CSS (`shrink-fade`, `fade-only`, `bloom`) — curve selected via `data-ca-curve` attribute on the section; `prefers-reduced-motion` suppresses the CA animation
- Tweak pane removed now that values are finalized
- upNEXT News role corrected to Executive Producer

## Test plan

- [ ] Scroll to the credits section and hover rows — red/blue CA flash appears on the hovered title and fades smoothly
- [ ] Move between rows — flash retriggers on each new row
- [ ] Move pointer out of the list — non-hovered rows fade back over ~1s, no snap
- [ ] Enable macOS Reduce Motion — CA shadow suppressed, dim effect remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)