### PR TITLE
fix(nav): restore pill-nav CSS dropped in index2.css → index.css rename

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -277,6 +277,56 @@ body.show-grid .bg-columns {
   visibility: hidden;
 }
 
+/* =====================================================
+   FLOATING TEXT NAVIGATION
+====================================================== */
+.pill-nav {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + clamp(0.75rem, 2vh, 1.5rem));
+  right: var(--container-padding);
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 0.4s ease,
+    visibility 0.4s ease;
+}
+
+.pill-nav.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.pill-nav__item {
+  font-family: var(--ff-body);
+  font-size: 0.7rem;
+  font-weight: 400;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: oklch(0.968 0.006 75 / 0.4);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.pill-nav__item:hover {
+  color: oklch(0.968 0.006 75 / 0.85);
+}
+
+.pill-nav__item.is-active {
+  color: oklch(0.968 0.006 75 / 0.9);
+}
+
+@media (max-width: 768px) {
+  .pill-nav {
+    display: none;
+  }
+}
+
 /* Color trail clone words inside mask wrappers */
 .color-trail-word {
   opacity: 1;


### PR DESCRIPTION
## Summary

Same root cause as PR #15: the May 28–30 CSS reorganization (`index2.css` → `index.css`) dropped the `.pill-nav` block.

**Impact without this fix:** The nav element has no default hidden state, so it renders in the top-right corner on every scroll position. `nav.js` correctly toggles `.is-visible` but without a CSS rule that class has no effect.

**Restores:**
- `.pill-nav` — fixed position, default hidden (`opacity: 0; visibility: hidden`)
- `.pill-nav.is-visible` — show on scroll past hero
- `.pill-nav__item` — link styling
- `.pill-nav__item:hover` / `.pill-nav__item.is-active` — interaction states
- Mobile: `display: none` below 768px

🤖 Generated with [Claude Code](https://claude.com/claude-code)