### PR TITLE
fix(credits): preserve logo silhouette filter through hover-dim cascade

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -751,15 +751,30 @@ body.show-grid .bg-columns {
   letter-spacing: 0.07em;
 }
 
-.credit-row__platform--logo {
+/* Double class (0-2-0) beats the shared .credit-row__platform rule (0-1-0) below. */
+.credit-row__platform.credit-row__platform--logo {
   height: 0.95rem;
   width: auto;
   max-width: 8rem;
   object-fit: contain;
   object-position: left center;
   display: block;
-  filter: brightness(0) invert(var(--credits-logo-invert, 0));
   opacity: 0.85;
+  filter: brightness(0) invert(var(--credits-logo-invert, 0)) blur(0px);
+  transition:
+    filter var(--credits-dim-duration) var(--credits-dim-ease),
+    opacity var(--credits-dim-duration) var(--credits-dim-ease);
+}
+
+/* Dim state: preserve silhouette, add blur. Specificity must beat the hover-dim rule below. */
+.credits-list.is-row-hovered .credit-row__header .credit-row__platform.credit-row__platform--logo {
+  filter: brightness(0) invert(var(--credits-logo-invert, 0)) blur(var(--credits-dim-blur));
+}
+
+/* Active (hovered) row: restore full-opacity silhouette. */
+.credits-list.is-row-hovered .credit-row__header.is-hovered .credit-row__platform.credit-row__platform--logo {
+  opacity: 0.85;
+  filter: brightness(0) invert(var(--credits-logo-invert, 0)) blur(0px);
 }
 
 .credit-row__title,


### PR DESCRIPTION
## Summary

Fixes the bug identified in PR #17 review by the Codex bot.

**Root cause:** `.credit-row__platform--logo` (specificity 0-1-0) was overridden by the shared `.credit-row__platform { filter: blur(0px) }` rule that appears later in `index.css` with equal specificity — so `brightness(0) invert(...)` never applied. The hover-dim rule (`filter: blur(var(--credits-dim-blur))`) had the same override problem, silently replacing the silhouette filter with a plain blur.

**Fix:** Use a double-class selector (`.credit-row__platform.credit-row__platform--logo`, 0-2-0) for the base logo rule, and add two matching high-specificity overrides for the dim and active-row hover states that include the full `brightness(0) invert(var(--credits-logo-invert, 0)) blur(N)` chain. Logos now render as correct monochrome silhouettes in all states.

## Test plan

- [ ] In the default light credits state, logo rows (Discovery, Netflix, PBS, etc.) render as dark/black silhouettes (not invisible white-on-white)
- [ ] Hover a different row: logo rows dim (opacity + blur), silhouette shape preserved — not replaced by plain blur
- [ ] Hover the logo row itself: full-opacity black silhouette
- [ ] Expand a row: section inverts dark, logos flip to white silhouettes
- [ ] Collapse: logos return to black silhouettes

🤖 Generated with [Claude Code](https://claude.com/claude-code)