### PR TITLE
Snap-frame viewfinder cursor + state-rot fix

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -349,8 +349,8 @@ Neither page type uses a strict mathematical spacing scale. Use `--section-paddi
 | Layer | Selector | z-index | Notes |
 |-------|----------|---------|-------|
 | Preloader | `.loading-overlay` | 10000 | Removed from DOM after exit |
-| Cursor dot | `.custom-cursor-dot` | 10000 | `gsap.quickTo` positioned |
-| Cursor ring | `.custom-cursor-ring` | 10000 | `gsap.quickTo` positioned, trails dot |
+| Cursor dot | `.custom-cursor-dot` | 10000 | `gsap.quickTo` positioned, `mix-blend-mode: difference` |
+| Cursor frame | `.custom-cursor-frame` | 9999 | 16:9 bracket frame, trails dot; expands or snaps to `[data-cursor-snap]` targets |
 | Hero name (header) | `.hero-fixed-name-container > #hero-name-fixed` | 40 | Flip-animated between hero and fixed positions |
 | Hero subtitle (fixed) | `#hero-subtitle-fixed` | 40 | Tracks title bottom edge, fades on scroll |
 | Hero social (fixed) | `#hero-social-fixed` | 40 | Tracks title bottom edge, fades on scroll |
@@ -587,11 +587,17 @@ SCRUB.smooth  = 1.5   // cinematic, used by hero zoom and case study parallax
 - After exit: `.loading-overlay` removed from DOM, `'loadingComplete'` event dispatched → hero init begins
 
 **Custom Cursor** (`src/components/custom-cursor.js`):
-- `.custom-cursor-dot` (10px filled) + `.custom-cursor-ring` (30px outline), both `position: fixed`, z-index 10000
-- `gsap.quickTo`: dot x/y `0.3s power2.out`, ring x/y `0.7s power2.out` (trailing effect)
-- Hero section only. Skip on touch devices and `prefers-reduced-motion`.
-- Link/button hover: dot `scale→0`, ring `scale→2` (0.3s); mouseleave: both `scale→1`
-- Scroll: ring nudged `delta * 1.2` clamped ±5px, returns after 80ms
+- Viewfinder cursor: `.custom-cursor-dot` (small filled dot) + `.custom-cursor-frame` (16:9 box, base 40×22) with four `.custom-cursor-corner` L-bracket children. Both `position: fixed`, `mix-blend-mode: difference`.
+- `gsap.quickTo`: dot x/y `0.3s power2.out`, frame x/y `0.7s power2.out` (trailing effect)
+- `index.html` only (initialized in `main.js`). Skip on touch devices and `prefers-reduced-motion`.
+- **Two hover behaviors**, selected per element:
+  - **Expand** (default for inline `a`, `button`): dot `scale→0`; corners translate outward 5px (`0.5s power2.out`). Mouseleave resets corners to 0 and dot to 1.
+  - **Snap-frame** (opt-in via `data-cursor-snap`): dot `scale→0` (0.2s); frame resizes + repositions to wrap the target's `getBoundingClientRect` + 10px pad, `0.45s power3.out`. A `framing` flag gates the `quickTo` follow so the frame stays locked to the target. Mouseleave resets frame to base 40×22 (`0.4s power2.out`).
+- **`data-cursor-snap` convention**: add the attribute to any element that should snap. Use it for well-bounded targets with a pleasing aspect ratio (buttons, gallery cards). Avoid it on tiny inline text links (use expand) and on full-width rows (a wrapped full-width row reads as a letterbox bar — snap an inner element like a title instead).
+  - Currently applied: `.cta-contact-btn`, `.newsletter-submit` (index.html), and `.gallery-card` (injected by `build/inject-gallery.js`).
+  - Gallery cards add `.is-cursor-snapping` while wrapped; CSS hides the card's own `.gallery-card-corner` to avoid a doubled frame.
+- Scroll: frame nudged `delta * 1.2` clamped ±5px, returns after 80ms (skipped while `framing`).
+- **On-light gotcha**: the off-white frame + `mix-blend-mode: difference` reads well on dark and mid-tone backgrounds, but goes low-contrast on near-white surfaces (e.g. the inverted/expanded credits panel). Resolve per-section before snapping content over light backgrounds (see `cursor-lab.html` for on-light variant experiments).
 
 **Hero Z-Depth** (`src/sections/hero.js`):
 - ScrollTrigger: `start: 'top top'`, `end: '+=150%'`, `scrub: 1.5`

--- a/build/inject-gallery.js
+++ b/build/inject-gallery.js
@@ -112,7 +112,7 @@ function renderGalleryCards(projects) {
                     <a class="card-link" href="${detailUrl}" aria-label="${escAttr(p.title)}"></a>`
         : '';
 
-      return `                <article class="${classes}" data-project="${escAttr(slug)}"${glightboxAttrs}${noVideoAttr}>${cardLinkHtml}
+      return `                <article class="${classes}" data-project="${escAttr(slug)}" data-cursor-snap${glightboxAttrs}${noVideoAttr}>${cardLinkHtml}
                     <div class="card-media">
                         <img
                             class="card-thumbnail"

--- a/cursor-lab.html
+++ b/cursor-lab.html
@@ -149,6 +149,51 @@
         position: relative;
       }
 
+      /* ---- Credits prototype (accordion-like rows) ---- */
+      .lab-credits {
+        --c-bg: var(--bg);
+        --c-text: var(--offwhite);
+        --c-border: rgba(240, 242, 241, 0.12);
+        background: var(--c-bg);
+        color: var(--c-text);
+        transition:
+          background 0.5s var(--ease-out-expo),
+          color 0.5s var(--ease-out-expo);
+        padding: 8px 0;
+      }
+      /* Inverted (expanded) state — light bg, dark text, like the live section */
+      .lab-credits.is-inverted {
+        --c-bg: var(--offwhite);
+        --c-text: #0b0b0c;
+        --c-border: rgba(11, 11, 12, 0.14);
+      }
+      .lab-credit-row {
+        display: grid;
+        grid-template-columns: 1.5rem 1fr 8rem 10rem;
+        align-items: center;
+        gap: 16px;
+        padding: 18px 8px;
+        border-bottom: 1px solid var(--c-border);
+        position: relative;
+      }
+      .lab-credit-icon {
+        font-weight: 300;
+        color: var(--c-text);
+        opacity: 0.55;
+      }
+      .lab-credit-title {
+        font-size: 1.2rem;
+        justify-self: start;
+        width: fit-content;
+      }
+      .lab-credit-platform,
+      .lab-credit-role {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        opacity: 0.6;
+      }
+
       /* =========================================================
          CUSTOM CURSOR ELEMENTS
          ========================================================= */
@@ -164,6 +209,31 @@
         pointer-events: none;
         z-index: 9999;
         opacity: 0;
+        mix-blend-mode: difference; /* match production dot */
+      }
+
+      /* ---- Cursor-on-light experiments (Phase 4 follow-up) ----
+         The off-white cursor + mix-blend difference goes near-invisible on the
+         light inverted credits panel. These body-class variants test fixes when
+         the cursor is over a light region (toggled by JS when hovering credits). */
+
+      /* Variant B: solid dark cursor, no blend (crisp on light). */
+      body.cursor-light-b .lab-frame,
+      body.cursor-light-b .lab-dot {
+        mix-blend-mode: normal;
+      }
+      body.cursor-light-b .lab-dot {
+        background: #0b0b0c;
+      }
+      body.cursor-light-b .lab-corner::before,
+      body.cursor-light-b .lab-corner::after {
+        background: #0b0b0c;
+      }
+
+      /* Variant C: alternate blend (exclusion) instead of difference. */
+      body.cursor-light-c .lab-frame,
+      body.cursor-light-c .lab-dot {
+        mix-blend-mode: exclusion;
       }
 
       /* The frame: a 16:9 box. In bracket mode only the corners show.
@@ -178,6 +248,7 @@
         pointer-events: none;
         z-index: 9998;
         opacity: 0;
+        mix-blend-mode: difference; /* match production cursor — visible on light + dark */
       }
       .lab-frame.is-outline {
         border: 1px solid var(--offwhite);
@@ -272,7 +343,7 @@
       }
     </style>
   </head>
-  <body class="lab-active form-frame-dot hover-expand">
+  <body class="lab-active form-frame-dot hover-snap">
     <div class="controls">
       <fieldset>
         <legend>Cursor form</legend>
@@ -292,11 +363,11 @@
       <fieldset>
         <legend>Hover behavior</legend>
         <label
-          ><input type="radio" name="hover" value="expand" checked /> A ·
+          ><input type="radio" name="hover" value="expand" /> A ·
           Corners expand</label
         >
         <label
-          ><input type="radio" name="hover" value="snap" /> B · Snap-frame
+          ><input type="radio" name="hover" value="snap" checked /> B · Snap-frame
           target</label
         >
         <label
@@ -341,6 +412,47 @@
           <div class="card" data-target>Project Four</div>
         </div>
       </section>
+
+      <section>
+        <h2>
+          Credits rows (accordion)
+          <button class="lab-btn" id="invert-toggle" style="margin-left: 16px; padding: 6px 14px; font-size: 0.7rem;">
+            Toggle inverted bg
+          </button>
+          <button class="lab-btn" id="target-toggle" style="margin-left: 8px; padding: 6px 14px; font-size: 0.7rem;">
+            Target: <span id="target-mode-label">title</span>
+          </button>
+          <button class="lab-btn" id="lightmode-toggle" style="margin-left: 8px; padding: 6px 14px; font-size: 0.7rem;">
+            On-light: <span id="lightmode-label">A difference</span>
+          </button>
+        </h2>
+        <p style="font-size: 0.78rem; color: var(--muted); max-width: 60ch; line-height: 1.5;">
+          "Target: title" wraps just the title text (tasteful viewfinder).
+          "Target: row" wraps the full-width row (letterbox bar). Toggle the
+          background to confirm frame visibility on light + dark
+          (mix-blend-mode: difference).
+        </p>
+        <div class="lab-credits" id="lab-credits">
+          <div class="lab-credit-row">
+            <span class="lab-credit-icon">+</span>
+            <span class="lab-credit-title">Wyatt Earp and the Cowboy War</span>
+            <span class="lab-credit-platform">Netflix</span>
+            <span class="lab-credit-role">Dev &amp; Production</span>
+          </div>
+          <div class="lab-credit-row">
+            <span class="lab-credit-icon">+</span>
+            <span class="lab-credit-title">Sitting Bull</span>
+            <span class="lab-credit-platform">History</span>
+            <span class="lab-credit-role">Showrunner</span>
+          </div>
+          <div class="lab-credit-row">
+            <span class="lab-credit-icon">+</span>
+            <span class="lab-credit-title">Crystal Echoes</span>
+            <span class="lab-credit-platform">Paramount+</span>
+            <span class="lab-credit-role">EP</span>
+          </div>
+        </div>
+      </section>
     </main>
 
     <!-- cursor nodes -->
@@ -366,7 +478,7 @@
       const timeEl = frame.querySelector('.lab-time');
 
       let form = 'frame-dot';
-      let hover = 'expand';
+      let hover = 'snap';
       let framing = false; // true while snap-framing a target
 
       // Base frame size (at rest)
@@ -486,6 +598,63 @@
       );
 
       applyForm('frame-dot');
+
+      // ---- Credits inversion toggle (prototype) ----
+      const invertToggle = document.getElementById('invert-toggle');
+      const labCredits = document.getElementById('lab-credits');
+      if (invertToggle && labCredits) {
+        invertToggle.addEventListener('click', () =>
+          labCredits.classList.toggle('is-inverted')
+        );
+      }
+
+      // ---- Credits target-mode toggle: title (inner span) vs row (full width) ----
+      const targetToggle = document.getElementById('target-toggle');
+      const targetModeLabel = document.getElementById('target-mode-label');
+      let creditTargetMode = 'title';
+      function bindCreditTargets() {
+        labCredits.querySelectorAll('.lab-credit-row').forEach((row) => {
+          const sel = creditTargetMode === 'title' ? row.querySelector('.lab-credit-title') : row;
+          row.querySelectorAll('[data-target]').forEach((el) => {
+            el.removeAttribute('data-target');
+            el.removeEventListener('mouseenter', onEnter);
+            el.removeEventListener('mouseleave', onLeave);
+          });
+          row.removeAttribute('data-target');
+          row.removeEventListener('mouseenter', onEnter);
+          row.removeEventListener('mouseleave', onLeave);
+          sel.setAttribute('data-target', '');
+          sel.addEventListener('mouseenter', onEnter);
+          sel.addEventListener('mouseleave', onLeave);
+        });
+      }
+      if (targetToggle && labCredits) {
+        bindCreditTargets();
+        targetToggle.addEventListener('click', () => {
+          creditTargetMode = creditTargetMode === 'title' ? 'row' : 'title';
+          targetModeLabel.textContent = creditTargetMode;
+          bindCreditTargets();
+        });
+      }
+
+      // ---- Cursor-on-light variant cycle: A difference -> B solid-dark -> C exclusion ----
+      const lightToggle = document.getElementById('lightmode-toggle');
+      const lightLabel = document.getElementById('lightmode-label');
+      const lightModes = [
+        { cls: '', label: 'A difference' },
+        { cls: 'cursor-light-b', label: 'B solid-dark' },
+        { cls: 'cursor-light-c', label: 'C exclusion' },
+      ];
+      let lightIdx = 0;
+      if (lightToggle) {
+        lightToggle.addEventListener('click', () => {
+          document.body.classList.remove('cursor-light-b', 'cursor-light-c');
+          lightIdx = (lightIdx + 1) % lightModes.length;
+          const m = lightModes[lightIdx];
+          if (m.cls) document.body.classList.add(m.cls);
+          lightLabel.textContent = m.label;
+        });
+      }
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -258,17 +258,17 @@
               Nonfiction Video Development &amp; Production
             </p>
             <div class="hero-social">
-              <a href="https://www.linkedin.com/in/randycounsman/" target="_blank" rel="noopener" class="social-icon" aria-label="LinkedIn">
+              <a href="https://www.linkedin.com/in/randycounsman/" target="_blank" rel="noopener" class="social-icon" aria-label="LinkedIn" data-cursor-snap>
                 <svg viewBox="0 0 24 24" fill="currentColor" width="24" height="24">
                   <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
                 </svg>
               </a>
-              <a href="https://vimeo.com/randycounsman" target="_blank" rel="noopener" class="social-icon" aria-label="Vimeo">
+              <a href="https://vimeo.com/randycounsman" target="_blank" rel="noopener" class="social-icon" aria-label="Vimeo" data-cursor-snap>
                 <svg viewBox="0 0 24 24" fill="currentColor" width="24" height="24">
                   <path d="M23.977 6.416c-.105 2.338-1.739 5.543-4.894 9.609-3.268 4.247-6.026 6.37-8.29 6.37-1.409 0-2.578-1.294-3.553-3.881L5.322 11.4C4.603 8.816 3.834 7.522 3.01 7.522c-.179 0-.806.378-1.881 1.132L0 7.197c1.185-1.044 2.351-2.084 3.501-3.128C5.08 2.701 6.266 1.984 7.055 1.91c1.867-.18 3.016 1.1 3.447 3.838.465 2.953.789 4.789.971 5.507.539 2.45 1.131 3.674 1.776 3.674.502 0 1.256-.796 2.265-2.385 1.004-1.589 1.54-2.797 1.612-3.628.144-1.371-.395-2.061-1.614-2.061-.574 0-1.167.121-1.777.391 1.186-3.868 3.434-5.757 6.762-5.637 2.473.06 3.628 1.664 3.493 4.797l-.013.01z"/>
                 </svg>
               </a>
-              <a href="mailto:RandyCounsman@gmail.com" class="social-icon" aria-label="Email">
+              <a href="mailto:RandyCounsman@gmail.com" class="social-icon" aria-label="Email" data-cursor-snap>
                 <svg viewBox="0 0 24 24" fill="currentColor" width="24" height="24">
                   <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
                 </svg>

--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@
                     autocomplete="email"
                   />
                   <input type="hidden" name="embed" value="1" />
-                  <button type="submit" class="newsletter-submit">
+                  <button type="submit" class="newsletter-submit" data-cursor-snap>
                     Subscribe
                   </button>
                 </div>
@@ -359,7 +359,7 @@
 
               <hr class="cta-divider" />
 
-              <a href="contact.html" class="cta-contact-btn">
+              <a href="contact.html" class="cta-contact-btn" data-cursor-snap>
                 Get in Touch
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                   <path

--- a/src/components/custom-cursor.js
+++ b/src/components/custom-cursor.js
@@ -1,108 +1,236 @@
 import { gsap } from '../animations/scroll-defaults.js';
 
 export function initCustomCursor() {
-  // Skip on touch devices
   if ('ontouchstart' in window) return () => {};
-
-  // Respect prefers-reduced-motion
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches)
     return () => {};
 
-  // Target sections
-  const sections = document.querySelectorAll('.hero-section, .portal-scene');
-  if (!sections.length) return () => {};
-  const cursorRoots = [...sections];
-
-  // Create cursor elements (fixed position, not per-section)
   const dot = document.createElement('div');
   dot.className = 'custom-cursor-dot';
-  const ring = document.createElement('div');
-  ring.className = 'custom-cursor-ring';
+
+  const frame = document.createElement('div');
+  frame.className = 'custom-cursor-frame';
+  frame.innerHTML =
+    '<span class="custom-cursor-corner custom-cursor-corner-lt"></span>' +
+    '<span class="custom-cursor-corner custom-cursor-corner-rt"></span>' +
+    '<span class="custom-cursor-corner custom-cursor-corner-lb"></span>' +
+    '<span class="custom-cursor-corner custom-cursor-corner-rb"></span>';
+
   document.body.appendChild(dot);
-  document.body.appendChild(ring);
+  document.body.appendChild(frame);
 
-  let isActive = false;
+  const corners = {
+    lt: frame.querySelector('.custom-cursor-corner-lt'),
+    rt: frame.querySelector('.custom-cursor-corner-rt'),
+    lb: frame.querySelector('.custom-cursor-corner-lb'),
+    rb: frame.querySelector('.custom-cursor-corner-rb'),
+  };
+
+  // Base frame size — must match .custom-cursor-frame in index.css (40×22, 16:9)
+  const BASE_W = 40;
+  const BASE_H = 22;
+  const SNAP_PAD = 10;
+
   let lastMouseY = 0;
+  // When true the frame is wrapped to a target and must NOT follow the cursor.
+  let framing = false;
 
-  // gsap.quickTo() for optimal performance on frequent mousemove
   const dotX = gsap.quickTo(dot, 'x', { duration: 0.3, ease: 'power2.out' });
   const dotY = gsap.quickTo(dot, 'y', { duration: 0.3, ease: 'power2.out' });
-  const ringX = gsap.quickTo(ring, 'x', { duration: 0.7, ease: 'power2.out' });
-  const ringY = gsap.quickTo(ring, 'y', { duration: 0.7, ease: 'power2.out' });
+  const frameX = gsap.quickTo(frame, 'x', {
+    duration: 0.7,
+    ease: 'power2.out',
+  });
+  const frameY = gsap.quickTo(frame, 'y', {
+    duration: 0.7,
+    ease: 'power2.out',
+  });
 
   function handleMouseMove(e) {
-    if (!isActive) return;
+    gsap.to([dot, frame], { opacity: 1, duration: 0.3, overwrite: 'auto' });
     lastMouseY = e.clientY;
     dotX(e.clientX);
     dotY(e.clientY);
-    ringX(e.clientX);
-    ringY(e.clientY);
+    if (!framing) {
+      frameX(e.clientX);
+      frameY(e.clientY);
+    }
   }
 
-  // On scroll, nudge ring via quickTo then ease back when scrolling stops
   let lastScrollY = window.scrollY;
   let scrollReturnTimer;
   function handleScroll() {
-    if (!isActive) return;
-    const delta = window.scrollY - lastScrollY;
     lastScrollY = window.scrollY;
+    if (framing) return;
+    const delta = window.scrollY - lastScrollY;
     const offset = Math.min(Math.max(delta * 1.2, -5), 5);
-    ringY(lastMouseY + offset);
+    frameY(lastMouseY + offset);
     clearTimeout(scrollReturnTimer);
-    scrollReturnTimer = setTimeout(() => ringY(lastMouseY), 80);
+    scrollReturnTimer = setTimeout(() => frameY(lastMouseY), 80);
   }
 
-  // Section enter/leave — show/hide cursor elements
-  function handleSectionEnter(e) {
-    // Jump to position immediately on enter to avoid fly-in from (0,0)
-    gsap.set([dot, ring], { x: e.clientX, y: e.clientY });
-    isActive = true;
-    gsap.to([dot, ring], { opacity: 1, duration: 0.3 });
-  }
-
-  function handleSectionLeave() {
-    isActive = false;
-    gsap.to([dot, ring], { opacity: 0, duration: 0.3 });
-  }
-
-  // Hover on links/buttons — dot shrinks, ring grows
   function handleInteractiveEnter() {
-    gsap.to(dot, { scale: 0, duration: 0.3 });
-    gsap.to(ring, { scale: 2, duration: 0.3 });
+    const d = 5;
+    gsap.to(dot, { scale: 0, duration: 0.3, overwrite: 'auto' });
+    gsap.to(corners.lt, {
+      x: -d,
+      y: -d,
+      duration: 0.5,
+      ease: 'power2.out',
+      overwrite: 'auto',
+    });
+    gsap.to(corners.rt, {
+      x: d,
+      y: -d,
+      duration: 0.5,
+      ease: 'power2.out',
+      overwrite: 'auto',
+    });
+    gsap.to(corners.lb, {
+      x: -d,
+      y: d,
+      duration: 0.5,
+      ease: 'power2.out',
+      overwrite: 'auto',
+    });
+    gsap.to(corners.rb, {
+      x: d,
+      y: d,
+      duration: 0.5,
+      ease: 'power2.out',
+      overwrite: 'auto',
+    });
   }
 
   function handleInteractiveLeave() {
-    gsap.to(dot, { scale: 1, duration: 0.3 });
-    gsap.to(ring, { scale: 1, duration: 0.3 });
+    gsap.to(dot, { scale: 1, duration: 0.3, overwrite: 'auto' });
+    Object.values(corners).forEach((c) =>
+      gsap.to(c, {
+        x: 0,
+        y: 0,
+        duration: 0.45,
+        ease: 'power2.out',
+        overwrite: 'auto',
+      })
+    );
   }
 
-  // Attach listeners
+  let snappedEl = null;
+
+  function snapToTarget(e) {
+    const el = e.currentTarget;
+    framing = true;
+    snappedEl = el;
+    el.classList.add('is-cursor-snapping');
+    gsap.to(dot, { scale: 0, duration: 0.2, overwrite: 'auto' });
+    const r = el.getBoundingClientRect();
+    const w = r.width + SNAP_PAD * 2;
+    const h = r.height + SNAP_PAD * 2;
+    // CSS centers base frame via top/left = -BASE/2; offset x/y so the resized frame stays centered on target.
+    gsap.to(frame, {
+      x: r.left + r.width / 2 + BASE_W / 2 - w / 2,
+      y: r.top + r.height / 2 + BASE_H / 2 - h / 2,
+      width: w,
+      height: h,
+      duration: 0.45,
+      ease: 'power3.out',
+      overwrite: 'auto',
+    });
+  }
+
+  function resetFrame() {
+    framing = false;
+    if (snappedEl) {
+      snappedEl.classList.remove('is-cursor-snapping');
+      snappedEl = null;
+    }
+    gsap.to(dot, { scale: 1, duration: 0.3, overwrite: 'auto' });
+    gsap.to(frame, {
+      width: BASE_W,
+      height: BASE_H,
+      duration: 0.4,
+      ease: 'power2.out',
+      overwrite: 'auto',
+    });
+    Object.values(corners).forEach((c) =>
+      gsap.to(c, {
+        x: 0,
+        y: 0,
+        duration: 0.45,
+        ease: 'power2.out',
+        overwrite: 'auto',
+      })
+    );
+  }
+
   document.addEventListener('mousemove', handleMouseMove);
   window.addEventListener('scroll', handleScroll, { passive: true });
 
-  cursorRoots.forEach((root) => {
-    root.addEventListener('mouseenter', handleSectionEnter);
-    root.addEventListener('mouseleave', handleSectionLeave);
+  // Delegated hover handling so dynamically-added targets (e.g. credits titles
+  // built after a fetch) are covered without re-wiring. mouseover/mouseout
+  // bubble, unlike mouseenter/mouseleave.
+  const SNAP_SELECTOR = '[data-cursor-snap]';
+  const EXPAND_SELECTOR = 'a, button, .gallery-card';
+  let activeSnapEl = null;
+  let activeExpandEl = null;
 
-    root.querySelectorAll('a, button').forEach((el) => {
-      el.addEventListener('mouseenter', handleInteractiveEnter);
-      el.addEventListener('mouseleave', handleInteractiveLeave);
-    });
-  });
+  function targetFor(node) {
+    if (!(node instanceof Element)) return { snap: null, expand: null };
+    const snap = node.closest(SNAP_SELECTOR);
+    if (snap) return { snap, expand: null };
+    const expand = node.closest(EXPAND_SELECTOR);
+    return { snap: null, expand };
+  }
 
-  // Return cleanup function
+  function handleMouseOver(e) {
+    const { snap, expand } = targetFor(e.target);
+
+    if (snap && snap !== activeSnapEl) {
+      if (activeExpandEl) {
+        handleInteractiveLeave();
+        activeExpandEl = null;
+      }
+      activeSnapEl = snap;
+      snapToTarget({ currentTarget: snap });
+      return;
+    }
+
+    if (expand && expand !== activeExpandEl) {
+      if (activeSnapEl) {
+        resetFrame();
+        activeSnapEl = null;
+      }
+      activeExpandEl = expand;
+      handleInteractiveEnter();
+    }
+  }
+
+  function handleMouseOut(e) {
+    // Only act when leaving the active target entirely (relatedTarget outside it).
+    const to = e.relatedTarget;
+    if (activeSnapEl && (!to || !activeSnapEl.contains(to))) {
+      resetFrame();
+      activeSnapEl = null;
+    }
+    if (
+      activeExpandEl &&
+      (!to || !activeExpandEl.contains(to)) &&
+      !(to instanceof Element && to.closest(EXPAND_SELECTOR) === activeExpandEl)
+    ) {
+      handleInteractiveLeave();
+      activeExpandEl = null;
+    }
+  }
+
+  document.addEventListener('mouseover', handleMouseOver);
+  document.addEventListener('mouseout', handleMouseOut);
+
   return () => {
     document.removeEventListener('mousemove', handleMouseMove);
     window.removeEventListener('scroll', handleScroll);
-    cursorRoots.forEach((root) => {
-      root.removeEventListener('mouseenter', handleSectionEnter);
-      root.removeEventListener('mouseleave', handleSectionLeave);
-      root.querySelectorAll('a, button').forEach((el) => {
-        el.removeEventListener('mouseenter', handleInteractiveEnter);
-        el.removeEventListener('mouseleave', handleInteractiveLeave);
-      });
-    });
+    document.removeEventListener('mouseover', handleMouseOver);
+    document.removeEventListener('mouseout', handleMouseOut);
     dot.remove();
-    ring.remove();
+    frame.remove();
   };
 }

--- a/src/components/custom-cursor.js
+++ b/src/components/custom-cursor.js
@@ -31,23 +31,26 @@ export function initCustomCursor() {
   const BASE_H = 22;
   const SNAP_PAD = 10;
 
+  let lastMouseX = 0;
   let lastMouseY = 0;
   // When true the frame is wrapped to a target and must NOT follow the cursor.
   let framing = false;
 
   const dotX = gsap.quickTo(dot, 'x', { duration: 0.3, ease: 'power2.out' });
   const dotY = gsap.quickTo(dot, 'y', { duration: 0.3, ease: 'power2.out' });
-  const frameX = gsap.quickTo(frame, 'x', {
-    duration: 0.7,
-    ease: 'power2.out',
-  });
-  const frameY = gsap.quickTo(frame, 'y', {
-    duration: 0.7,
-    ease: 'power2.out',
-  });
+  // quickTo's internal tween gets its PropTweens killed by snapToTarget's
+  // overwrite:'auto', leaving the frame frozen after any snap. Rebuild on
+  // demand in resetFrame so the catch-up and subsequent mousemoves work.
+  let frameX = gsap.quickTo(frame, 'x', { duration: 0.7, ease: 'power2.out' });
+  let frameY = gsap.quickTo(frame, 'y', { duration: 0.7, ease: 'power2.out' });
+  function rebuildFrameQuick() {
+    frameX = gsap.quickTo(frame, 'x', { duration: 0.7, ease: 'power2.out' });
+    frameY = gsap.quickTo(frame, 'y', { duration: 0.7, ease: 'power2.out' });
+  }
 
   function handleMouseMove(e) {
     gsap.to([dot, frame], { opacity: 1, duration: 0.3, overwrite: 'auto' });
+    lastMouseX = e.clientX;
     lastMouseY = e.clientY;
     dotX(e.clientX);
     dotY(e.clientY);
@@ -57,12 +60,32 @@ export function initCustomCursor() {
     }
   }
 
+  function snapFrameToEl(el) {
+    const r = el.getBoundingClientRect();
+    const w = r.width + SNAP_PAD * 2;
+    const h = r.height + SNAP_PAD * 2;
+    return {
+      x: r.left + r.width / 2 + BASE_W / 2 - w / 2,
+      y: r.top + r.height / 2 + BASE_H / 2 - h / 2,
+      w,
+      h,
+    };
+  }
+
   let lastScrollY = window.scrollY;
   let scrollReturnTimer;
   function handleScroll() {
-    lastScrollY = window.scrollY;
-    if (framing) return;
+    // While snapped, re-pin the frame to the target's new viewport position
+    // each scroll tick. Without this, position:fixed leaves the frame parked
+    // at its initial screen coords while the target moves with the page.
+    if (framing && snappedEl) {
+      const { x, y } = snapFrameToEl(snappedEl);
+      gsap.set(frame, { x, y });
+      lastScrollY = window.scrollY;
+      return;
+    }
     const delta = window.scrollY - lastScrollY;
+    lastScrollY = window.scrollY;
     const offset = Math.min(Math.max(delta * 1.2, -5), 5);
     frameY(lastMouseY + offset);
     clearTimeout(scrollReturnTimer);
@@ -123,13 +146,11 @@ export function initCustomCursor() {
     snappedEl = el;
     el.classList.add('is-cursor-snapping');
     gsap.to(dot, { scale: 0, duration: 0.2, overwrite: 'auto' });
-    const r = el.getBoundingClientRect();
-    const w = r.width + SNAP_PAD * 2;
-    const h = r.height + SNAP_PAD * 2;
     // CSS centers base frame via top/left = -BASE/2; offset x/y so the resized frame stays centered on target.
+    const { x, y, w, h } = snapFrameToEl(el);
     gsap.to(frame, {
-      x: r.left + r.width / 2 + BASE_W / 2 - w / 2,
-      y: r.top + r.height / 2 + BASE_H / 2 - h / 2,
+      x,
+      y,
       width: w,
       height: h,
       duration: 0.45,
@@ -144,6 +165,13 @@ export function initCustomCursor() {
       snappedEl.classList.remove('is-cursor-snapping');
       snappedEl = null;
     }
+    // Rebuild the position quickTos — snap's gsap.to(...overwrite:'auto') strips
+    // their internal PropTweens, so they silently no-op until recreated.
+    rebuildFrameQuick();
+    // Kick them toward the last cursor position so the frame catches up even
+    // without a follow-up mousemove (snap target scrolling out of view, etc).
+    frameX(lastMouseX);
+    frameY(lastMouseY);
     gsap.to(dot, { scale: 1, duration: 0.3, overwrite: 'auto' });
     gsap.to(frame, {
       width: BASE_W,
@@ -170,6 +198,7 @@ export function initCustomCursor() {
   // built after a fetch) are covered without re-wiring. mouseover/mouseout
   // bubble, unlike mouseenter/mouseleave.
   const SNAP_SELECTOR = '[data-cursor-snap]';
+  const DEFAULT_SELECTOR = '[data-cursor-default]';
   const EXPAND_SELECTOR = 'a, button, .gallery-card';
   let activeSnapEl = null;
   let activeExpandEl = null;
@@ -178,6 +207,9 @@ export function initCustomCursor() {
     if (!(node instanceof Element)) return { snap: null, expand: null };
     const snap = node.closest(SNAP_SELECTOR);
     if (snap) return { snap, expand: null };
+    // Opt-out: element wants the default follow cursor, no expand.
+    // Checked AFTER snap so a snap descendant inside an opt-out ancestor still snaps.
+    if (node.closest(DEFAULT_SELECTOR)) return { snap: null, expand: null };
     const expand = node.closest(EXPAND_SELECTOR);
     return { snap: null, expand };
   }
@@ -230,6 +262,7 @@ export function initCustomCursor() {
     window.removeEventListener('scroll', handleScroll);
     document.removeEventListener('mouseover', handleMouseOver);
     document.removeEventListener('mouseout', handleMouseOut);
+    clearTimeout(scrollReturnTimer);
     dot.remove();
     frame.remove();
   };

--- a/src/components/custom-cursor.js
+++ b/src/components/custom-cursor.js
@@ -5,6 +5,8 @@ export function initCustomCursor() {
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches)
     return () => {};
 
+  document.body.classList.add('has-custom-cursor');
+
   const dot = document.createElement('div');
   dot.className = 'custom-cursor-dot';
 
@@ -258,6 +260,7 @@ export function initCustomCursor() {
   document.addEventListener('mouseout', handleMouseOut);
 
   return () => {
+    document.body.classList.remove('has-custom-cursor');
     document.removeEventListener('mousemove', handleMouseMove);
     window.removeEventListener('scroll', handleScroll);
     document.removeEventListener('mouseover', handleMouseOver);

--- a/src/sections/credits.js
+++ b/src/sections/credits.js
@@ -110,6 +110,7 @@ function buildRow(project) {
   const title = document.createElement('span');
   title.className = 'credit-row__title';
   title.textContent = project.title;
+  title.setAttribute('data-cursor-snap', '');
 
   const platform = document.createElement('span');
   platform.className = 'credit-row__platform';

--- a/src/styles/hero-aperture-dual.css
+++ b/src/styles/hero-aperture-dual.css
@@ -40,6 +40,9 @@
   perspective: 1200px;
   transform-style: preserve-3d;
   isolation: isolate;
+}
+
+body.has-custom-cursor .portal-scene {
   cursor: none;
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -133,31 +133,84 @@ body.show-grid .bg-columns {
    SECTION 1: HERO — APERTURE DUAL
    Pinned aperture scene (styles in hero-aperture-dual.css)
 ====================================================== */
-/* Custom cursor */
+/* Custom cursor — viewfinder (dot + 16:9 bracket frame) */
+body,
+body a,
+body button,
+body .gallery-card {
+  cursor: none;
+}
+
 .custom-cursor-dot {
   position: fixed;
-  top: -5px;
-  left: -5px;
-  width: 10px;
-  height: 10px;
+  top: -3px;
+  left: -3px;
+  width: 5px;
+  height: 5px;
   background-color: var(--color-offwhite);
   border-radius: 50%;
   pointer-events: none;
   z-index: 10000;
   opacity: 0;
+  mix-blend-mode: difference;
 }
 
-.custom-cursor-ring {
+.custom-cursor-frame {
   position: fixed;
-  top: -15px;
-  left: -15px;
-  width: 30px;
-  height: 30px;
-  border: 1px solid var(--color-offwhite);
-  border-radius: 50%;
+  top: -11px;
+  left: -20px;
+  width: 40px;
+  height: 22px;
   pointer-events: none;
-  z-index: 10000;
+  z-index: 9999;
   opacity: 0;
+  mix-blend-mode: difference;
+}
+
+.custom-cursor-corner {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+}
+
+.custom-cursor-corner::before,
+.custom-cursor-corner::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: var(--color-offwhite);
+}
+
+.custom-cursor-corner::before {
+  width: 100%;
+  height: 1px;
+}
+
+.custom-cursor-corner::after {
+  width: 1px;
+  height: 100%;
+}
+
+.custom-cursor-corner-lt { top: 0; left: 0; }
+.custom-cursor-corner-rt { top: 0; right: 0; }
+.custom-cursor-corner-lb { bottom: 0; left: 0; }
+.custom-cursor-corner-rb { bottom: 0; right: 0; }
+
+.custom-cursor-corner-lb::before,
+.custom-cursor-corner-lb::after,
+.custom-cursor-corner-rb::before,
+.custom-cursor-corner-rb::after {
+  top: auto;
+  bottom: 0;
+}
+
+.custom-cursor-corner-rt::before,
+.custom-cursor-corner-rt::after,
+.custom-cursor-corner-rb::before,
+.custom-cursor-corner-rb::after {
+  left: auto;
+  right: 0;
 }
 
 .hero-video-container {
@@ -474,7 +527,6 @@ body.show-grid .bg-columns {
   border-radius: 0;
   overflow: visible;
   background: var(--color-nearblack);
-  cursor: pointer;
 }
 
 .card-link {
@@ -639,6 +691,11 @@ body.show-grid .bg-columns {
   opacity: 1;
 }
 
+/* When the cursor viewfinder is wrapping a card, hide the card's own corners to avoid a doubled frame */
+.gallery-card.is-cursor-snapping .gallery-card-corner {
+  opacity: 0;
+}
+
 .gallery-card:focus-within {
   outline: 1px solid oklch(0.968 0.006 75 / 0.85);
   outline-offset: 4px;
@@ -756,7 +813,6 @@ body.show-grid .bg-columns {
   border: none;
   color: inherit;
   font: inherit;
-  cursor: pointer;
   text-align: left;
   transition: background 0.25s ease;
 }
@@ -789,6 +845,9 @@ body.show-grid .bg-columns {
   font-family: var(--ff-display);
   font-size: clamp(1.05rem, 2vw, 1.35rem);
   font-weight: 400;
+  /* Shrink-wrap so the cursor viewfinder snaps tightly to the title, not the full 1fr track. */
+  justify-self: start;
+  width: fit-content;
 }
 
 .credit-row__platform,
@@ -1116,7 +1175,6 @@ body.show-grid .bg-columns {
   background: var(--color-offwhite);
   border: 1px solid var(--color-offwhite);
   border-radius: 0 4px 4px 0;
-  cursor: pointer;
   transition: opacity 0.2s ease;
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -134,10 +134,10 @@ body.show-grid .bg-columns {
    Pinned aperture scene (styles in hero-aperture-dual.css)
 ====================================================== */
 /* Custom cursor — viewfinder (dot + 16:9 bracket frame) */
-body,
-body a,
-body button,
-body .gallery-card {
+body.has-custom-cursor,
+body.has-custom-cursor a,
+body.has-custom-cursor button,
+body.has-custom-cursor .gallery-card {
   cursor: none;
 }
 
@@ -192,10 +192,22 @@ body .gallery-card {
   height: 100%;
 }
 
-.custom-cursor-corner-lt { top: 0; left: 0; }
-.custom-cursor-corner-rt { top: 0; right: 0; }
-.custom-cursor-corner-lb { bottom: 0; left: 0; }
-.custom-cursor-corner-rb { bottom: 0; right: 0; }
+.custom-cursor-corner-lt {
+  top: 0;
+  left: 0;
+}
+.custom-cursor-corner-rt {
+  top: 0;
+  right: 0;
+}
+.custom-cursor-corner-lb {
+  bottom: 0;
+  left: 0;
+}
+.custom-cursor-corner-rb {
+  bottom: 0;
+  right: 0;
+}
 
 .custom-cursor-corner-lb::before,
 .custom-cursor-corner-lb::after,


### PR DESCRIPTION
## Summary
- Introduces the snap-frame viewfinder cursor: a base rectangle that follows the cursor and snaps to wrap targets marked `data-cursor-snap` (hero social icons, newsletter submit, CTA, credits titles).
- Fixes a state-rot bug where `gsap.quickTo`'s internal PropTweens get stripped by snap's `overwrite:'auto'`, freezing the rectangle at the first snap target so it never follows the cursor again. `resetFrame` now rebuilds the quickTos and kicks them toward the last cursor position.
- Re-pins the rectangle to the snap target on every scroll tick (was stuck at its initial viewport coords while the target moved with the page); fixes the dead `handleScroll` delta calc; adds a `data-cursor-default` opt-out for descendants that should keep the default follow cursor.

## Test plan
- [ ] Hover a hero social icon, then flick the mouse to the opposite side of the viewport — rectangle should glide back to the dot, not stay parked at the icon.
- [ ] Hover the CTA contact button and scroll without moving the mouse — rectangle should stay wrapped around the button as it scrolls up.
- [ ] Hover a `.gallery-card` (expand-only) — dot still shrinks, corners still spread, restores on leave.
- [ ] Verify hover snap still works after navigating between several snap targets in a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)